### PR TITLE
fix(cli): strategie for inginious with rst2markdown

### DIFF
--- a/cli/strategies/inginious-git.js
+++ b/cli/strategies/inginious-git.js
@@ -23,7 +23,7 @@ const rst2md = (str) => {
     try {
         const result = child_process.spawnSync(
             "pandoc",
-            ["--from=rst", "--to=markdown-fenced_code_attributes"],
+            ["--from=rst", "--to=markdown_strict-fenced_code_attributes+backtick_code_blocks"],
             {input: str, encoding: "utf-8"}
         );
         return result.stdout;


### PR DESCRIPTION
Ce fix permet de ne plus avoir la mauvaise traduction de fichier rst vers markdown. Particulièrement, quand il s'agissait de code ou d'image, la traduction se faisait de la mauvaise façon.